### PR TITLE
Adding channel method to MutlipleBroadcaster

### DIFF
--- a/src/MultipleBroadcaster.php
+++ b/src/MultipleBroadcaster.php
@@ -43,6 +43,24 @@ class MultipleBroadcaster extends Broadcaster
         $this->safe = Arr::get($config, 'safe', $this->safe);
         $this->broadcastManager = $broadcastManager;
     }
+    
+    /**
+     * Register a channel authenticator.
+     *
+     * @param  \Illuminate\Contracts\Broadcasting\HasBroadcastChannel|string  $channel
+     * @param  callable|string  $callback
+     * @param  array  $options
+     * @return $this
+     */
+    public function channel($channel, $callback, $options = [])
+    {
+        foreach ($this->connections as $connection)
+        {
+            $this->broadcastManager->connection($connection)->channel($channel, $callback, $options);
+        }
+
+        return $this;
+    }
 
     /**
      * Authenticate the incoming request for a given channel.


### PR DESCRIPTION
Hello,


i'm proposing to add a channel method to the multiple broadcaster, because currently channels are not forwarded to the broadcasters and in our case it's causing 403 from the auth method, because channels array is empty


Before the change, channels and channelOptions are empty
![Screenshot from 2023-02-06 11-29-28](https://user-images.githubusercontent.com/9606882/216948644-11af34e4-9231-408c-9d9a-87088e96b832.png)

After the change they are populated

![Screenshot from 2023-02-06 11-29-40](https://user-images.githubusercontent.com/9606882/216948735-9b70df95-a9bd-4493-8e49-6a14bf18a07e.png)


Also the same issue likely happens for methods like `resolveAuthenticatedUserUsing`, and all other methods that modify properties of the broadcaster

thanks.